### PR TITLE
support multiple PHP versions

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,4 @@ php_max_nesting_level: 200
 php_xdebug_var_display_max_depth: 3
 php_xdebug_var_display_max_children: 128
 php_xdebug_var_display_max_data: 512
+php_xdebug_cli_color: 0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,6 @@ php_xdebug_remote_port: "9000"
 php_xdebug_remote_log: /tmp/xdebug.log
 php_xdebug_idekey: XDEBUG
 php_max_nesting_level: 200
+php_xdebug_var_display_max_depth: 3
+php_xdebug_var_display_max_children: 128
+php_xdebug_var_display_max_data: 512

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,5 +5,6 @@
 - name: Copy xdebug INI into mods-available folder.
   template: >
     src=xdebug.ini.j2
-    dest=/etc/php/7.0/mods-available/xdebug.ini
+    dest={{ item }}
     owner=root group=root mode=644
+  with_items: "{{'/etc/php/*/mods-available/xdebug.ini' | fileglob}}"

--- a/templates/xdebug.ini.j2
+++ b/templates/xdebug.ini.j2
@@ -11,3 +11,4 @@ xdebug.max_nesting_level = {{ php_max_nesting_level }}
 xdebug.var_display_max_depth = {{ php_xdebug_var_display_max_depth }}
 xdebug.var_display_max_children = {{ php_xdebug_var_display_max_children }}
 xdebug.var_display_max_data = {{ php_xdebug_var_display_max_data }}
+xdebug.cli_color = {{ php_xdebug_cli_color }}

--- a/templates/xdebug.ini.j2
+++ b/templates/xdebug.ini.j2
@@ -8,3 +8,6 @@ xdebug.remote_handler="dbgp"
 xdebug.remote_log={{ php_xdebug_remote_log }}
 xdebug.idekey="{{ php_xdebug_idekey }}"
 xdebug.max_nesting_level = {{ php_max_nesting_level }}
+xdebug.var_display_max_depth = {{ php_xdebug_var_display_max_depth }}
+xdebug.var_display_max_children = {{ php_xdebug_var_display_max_children }}
+xdebug.var_display_max_data = {{ php_xdebug_var_display_max_data }}


### PR DESCRIPTION
Updates all xdebug.ini files in /etc/php/*/mods-available.

Note the use of with_items/fileglob is a workaround for this bug:
https://github.com/ansible/ansible/issues/17136

